### PR TITLE
Patch toBool function

### DIFF
--- a/src/main/java/cr0s/warpdrive/block/TileEntityAbstractBase.java
+++ b/src/main/java/cr0s/warpdrive/block/TileEntityAbstractBase.java
@@ -272,7 +272,19 @@ public abstract class TileEntityAbstractBase extends TileEntity implements IBloc
 		if (object instanceof Boolean) {
 			 return ((Boolean) object);
 		}
-		String string = object.toString();
+		
+		String string = null;
+		if (object instanceof Object[]) {
+		    if (((Object[]) object).length > 0){
+			string = ((Object[]) object)[0].toString();
+		    }
+		    else {
+			return false;
+		    }
+		}
+		else {
+		    string = object.toString();
+		}
 		return string.equals("true") || string.equals("1.0") || string.equals("1") || string.equals("y") || string.equals("yes");
 	}
 	

--- a/src/main/resources/assets/warpdrive/lua.ComputerCraft/warpdriveShipController/startup
+++ b/src/main/resources/assets/warpdrive/lua.ComputerCraft/warpdriveShipController/startup
@@ -4,6 +4,11 @@ if not term.isColor() then
 end
 print("loading...")
 
+if fs.exists("bgTask") then
+  print("Starting background service...")
+  bg bgTask
+end
+
 monitor_textScale = 0.5
 
 Style = {


### PR DESCRIPTION
Now better handles Object[] passed in as an Object.  This happens when the EnergyLift is activated or disabled via ComputerCraft.

Ideally, the correct fix would be to break this method out and overload it.  That way it is clear what is being expected and what is being returned.  Also, the Energy Lift and others should avoid passing in an Object[] and should only pass in the first element of the array.