### PR TITLE
Feature request: Schemetic generation; Mining Laser Pumping

### DIFF
--- a/src/main/java/cr0s/warpdrive/block/collection/TileEntityAbstractMiner.java
+++ b/src/main/java/cr0s/warpdrive/block/collection/TileEntityAbstractMiner.java
@@ -7,9 +7,11 @@ import cr0s.warpdrive.block.TileEntityAbstractLaser;
 import cr0s.warpdrive.config.WarpDriveConfig;
 import cr0s.warpdrive.data.FluidWrapper;
 import cr0s.warpdrive.data.InventoryWrapper;
+import cr0s.warpdrive.data.TankWrapper;
 import cr0s.warpdrive.data.Vector3;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -27,8 +29,9 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldServer;
-
 import net.minecraftforge.common.IPlantable;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
 
 public abstract class TileEntityAbstractMiner extends TileEntityAbstractLaser {
 	
@@ -55,11 +58,30 @@ public abstract class TileEntityAbstractMiner extends TileEntityAbstractLaser {
 		if (blockState.getBlock().isAir(blockState, world, blockPos)) {
 			return;
 		}
-		if (FluidWrapper.isFluid(blockState)) {
-			// Evaporate fluid
-			world.playSound(null, blockPos, net.minecraft.init.SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.BLOCKS, 0.5F,
-					2.6F + (world.rand.nextFloat() - world.rand.nextFloat()) * 0.8F);
-			
+		
+		final Fluid fluid = FluidWrapper.getFluid(blockState);
+		if (fluid != null) {// (this is a fluid block)
+			if ( WarpDriveConfig.MINING_LASER_PUMP_UPGRADE_HARVEST_FLUID
+			  && FluidWrapper.isSourceBlock(world, blockPos, blockState) ) {// (fluid collection is enabled & it's a source block)
+				final Collection<Object> connectedTanks = TankWrapper.getConnectedTanks(world, pos);
+				if (!connectedTanks.isEmpty()) {// (at least 1 tank is connected)
+					final FluidStack fluidStack = new FluidStack(fluid, 1000);
+					
+					final boolean fluidOverflowed = TankWrapper.addToTanks(world, pos, connectedTanks, fluidStack);
+					if (fluidOverflowed) {
+						// assume player wants to collect the fluid, hence stop the mining in case of overflow
+						setIsEnabled(false);
+					}
+					
+					// Collect Fluid
+					world.playSound(null, blockPos, fluid.getFillSound(fluidStack), SoundCategory.BLOCKS, 0.5F,
+								2.6F + (world.rand.nextFloat() - world.rand.nextFloat()) * 0.8F);
+				}
+			} else {
+				// Evaporate fluid
+				world.playSound(null, blockPos, net.minecraft.init.SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.BLOCKS, 0.5F,
+							2.6F + (world.rand.nextFloat() - world.rand.nextFloat()) * 0.8F);
+			}
 			// remove without updating neighbours
 			world.setBlockState(blockPos, Blocks.AIR.getDefaultState(), 2);
 			
@@ -78,14 +100,14 @@ public abstract class TileEntityAbstractMiner extends TileEntityAbstractLaser {
 			
 			// try to replant the crop
 			if ( itemStackDrops != null
-			  && blockState.getBlock() instanceof IGrowable) {
+			  && blockState.getBlock() instanceof IGrowable ) {
 				for (final ItemStack itemStackPlant : itemStackDrops) {
 					if (itemStackPlant.getItem() instanceof IPlantable) {
 						final IPlantable plantable = (IPlantable) itemStackPlant.getItem();
 						final IBlockState blockStatePlant = plantable.getPlant(world, blockPos);
 						if (WarpDriveConfig.LOGGING_COLLECTION) {
 							WarpDrive.logger.info(String.format("Drop includes %s which is plantable %s as block %s",
-							                                    itemStackPlant, plantable, blockStatePlant ));
+							                                    itemStackPlant, plantable, blockStatePlant));
 						}
 						final BlockPos blockPosSoil = blockPos.down();
 						final IBlockState blockStateSoil = getWorld().getBlockState(blockPosSoil);

--- a/src/main/java/cr0s/warpdrive/config/WarpDriveConfig.java
+++ b/src/main/java/cr0s/warpdrive/config/WarpDriveConfig.java
@@ -430,6 +430,7 @@ public class WarpDriveConfig {
 	public static double           MINING_LASER_MINE_SILKTOUCH_ENERGY_FACTOR = 1.5;
 	public static int              MINING_LASER_MINE_SILKTOUCH_DEUTERIUM_MB = 0;
 	public static double           MINING_LASER_MINE_FORTUNE_ENERGY_FACTOR = 1.5;
+	public static boolean          MINING_LASER_PUMP_UPGRADE_HARVEST_FLUID = false;
 	
 	// Laser tree farm
 	// oak      tree height is 8 to 11 logs + 2 leaves
@@ -1258,6 +1259,7 @@ public class WarpDriveConfig {
 			MINING_LASER_MINE_FORTUNE_ENERGY_FACTOR = Commons.clamp(0.01D, 1000.0D,
 					config.get("mining_laser", "fortune_energy_factor", MINING_LASER_MINE_FORTUNE_ENERGY_FACTOR, "Energy cost multiplier per fortune level").getDouble(MINING_LASER_MINE_FORTUNE_ENERGY_FACTOR));
 		}
+		MINING_LASER_PUMP_UPGRADE_HARVEST_FLUID = config.get("mining_laser", "pump_upgrade_harvest_fluid", MINING_LASER_PUMP_UPGRADE_HARVEST_FLUID, "Pump upgrade will actually pump fluid source if a tank is found, instead of just evaporating it").getBoolean(false);
 		
 		// Tree Farm
 		TREE_FARM_MAX_MEDIUMS_COUNT = Commons.clamp(1, 10,

--- a/src/main/java/cr0s/warpdrive/data/InventoryWrapper.java
+++ b/src/main/java/cr0s/warpdrive/data/InventoryWrapper.java
@@ -127,8 +127,11 @@ public class InventoryWrapper {
 					} else if (inventory instanceof IItemHandler) {
 						qtyLeft = addToInventory(itemStack, (IItemHandler) inventory);
 					} else {
-						WarpDrive.logger.error(String.format("Invalid inventory type %s, please report to mod author: %s",
-						                                    Commons.format(world, blockPos), inventory ));
+						if (Commons.throttleMe("addToInventories")){
+							WarpDrive.logger.error(String.format("Invalid inventory type %s of class %s at %s, please report to mod author",
+							                                     inventory, inventory.getClass(), Commons.format(world, blockPos) ));
+							break;
+						}
 					}
 					if (qtyLeft > 0) {
 						if (itemStackLeft == itemStack) {
@@ -141,7 +144,7 @@ public class InventoryWrapper {
 				}
 				if (qtyLeft > 0) {
 					if (WarpDriveConfig.LOGGING_COLLECTION) {
-						WarpDrive.logger.info(String.format("Overflow detected %s",
+						WarpDrive.logger.info(String.format("Overflow detected at %s",
 						                                    Commons.format(world, blockPos) ));
 					}
 					overflow = true;

--- a/src/main/java/cr0s/warpdrive/data/TankWrapper.java
+++ b/src/main/java/cr0s/warpdrive/data/TankWrapper.java
@@ -1,0 +1,132 @@
+package cr0s.warpdrive.data;
+
+import cr0s.warpdrive.Commons;
+import cr0s.warpdrive.WarpDrive;
+import cr0s.warpdrive.config.WarpDriveConfig;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockPos.MutableBlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidTank;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+// this is almost a copy of InventoryWrapper, but for fluids.
+
+public class TankWrapper {
+	
+	// WarpDrive methods
+	public static boolean isTank(final TileEntity tileEntity, final EnumFacing facing) {
+		boolean isTank = false;
+		
+		if (tileEntity instanceof IFluidTank) {
+			isTank = true;
+		}
+		
+		if (!isTank
+		    && tileEntity.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, facing)) {
+			isTank = true;
+		}
+		
+		return isTank;
+	}
+	
+	public static Object getTank(final TileEntity tileEntity, final EnumFacing facing) {
+		if (tileEntity instanceof IFluidTank) {
+			return tileEntity;
+		}
+		
+		if (tileEntity != null) {
+			return tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, facing);
+		}
+		
+		return null;
+	}
+	
+	public static @Nonnull Collection<Object> getConnectedTanks(final World world, final BlockPos blockPos) {
+		final Collection<Object> result = new ArrayList<>(6);
+		final Collection<IFluidHandler> resultCapabilities = new ArrayList<>(6);
+		final MutableBlockPos mutableBlockPos = new MutableBlockPos();
+		
+		for (final EnumFacing side : EnumFacing.VALUES) {
+			mutableBlockPos.setPos(blockPos.getX() + side.getXOffset(),
+			blockPos.getY() + side.getYOffset(),
+			blockPos.getZ() + side.getZOffset());
+			final TileEntity tileEntity = world.getTileEntity(mutableBlockPos);
+			
+			if (tileEntity instanceof IFluidTank) {
+				result.add(tileEntity);
+			} else if (tileEntity != null) {
+				final IFluidHandler fluidHandler = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
+				if (fluidHandler != null) {
+					resultCapabilities.add(fluidHandler);
+				}
+			}
+		}
+		
+		result.addAll(resultCapabilities);
+		return result;
+	}
+	
+	public static boolean addToConnectedTanks(final World world, final BlockPos blockPos, final FluidStack fluidStack) {
+		final List<FluidStack> fluidStacks = new ArrayList<>(1);
+		fluidStacks.add(fluidStack);
+		return addToConnectedTanks(world, blockPos, fluidStacks);
+	}
+	
+	public static boolean addToConnectedTanks(final World world, final BlockPos blockPos, final List<FluidStack> fluidStacks) {
+		final Collection<Object> inventories = getConnectedTanks(world, blockPos);
+		return addToTanks(world, blockPos, inventories, fluidStacks);
+	}
+	
+	public static boolean addToTanks(final World world, final BlockPos blockPos,
+	                                 final Collection<Object> tanks, final FluidStack fluidStack) {
+		final List<FluidStack> fluidStacks = new ArrayList<>(1);
+		fluidStacks.add(fluidStack);
+		
+		return addToTanks(world, blockPos, tanks, fluidStacks);
+	}
+	public static boolean addToTanks(final World world, final BlockPos blockPos,
+	                                 final Collection<Object> tanks, final List<FluidStack> fluidStacks) {
+		boolean overflow = false;
+		if (fluidStacks != null) {
+			for (final FluidStack fluidStack : fluidStacks) {
+				int qtyFilled = 0;
+				for (final Object tank : tanks) {
+					if (tank instanceof IFluidTank) {
+						qtyFilled = ((IFluidTank) tank).fill(fluidStack, true);
+					} else if (tank instanceof IFluidHandler) {
+						qtyFilled = ((IFluidHandler) tank).fill(fluidStack, true);
+					} else {
+						if (Commons.throttleMe("addToTanks")){
+							WarpDrive.logger.error(String.format("Invalid fluid tank type %s of class %s at %s, please report to mod author",
+							                                     tank, tank.getClass(), Commons.format(world, blockPos) ));
+							break;
+						}
+					}
+					if (fluidStack.amount > qtyFilled) {
+						fluidStack.amount -= qtyFilled;
+					} else {
+						break;
+					}
+				}
+				if (fluidStack.amount > qtyFilled) {
+					if (WarpDriveConfig.LOGGING_COLLECTION) {
+						WarpDrive.logger.info(String.format("Tank overflow detected at %s",
+						                                    Commons.format(world, blockPos)));
+					}
+					overflow = true;
+				}
+			}
+		}
+		return overflow;
+	}
+	
+}

--- a/src/main/resources/config/WarpDrive.xsd
+++ b/src/main/resources/config/WarpDrive.xsd
@@ -107,6 +107,7 @@
 		<xs:attribute name="blockState" type="xs:string" use="required" />
 		<xs:attribute name="minQuantity" type="xs:string" use="optional" />
 		<xs:attribute name="maxQuantity" type="xs:string" use="optional" />
+		<xs:attribute name="maxRetries" type="xs:string" use="optional" />
 		<xs:attribute name="mods" type="xs:string" use="optional" />
 	</xs:complexType>
 


### PR DESCRIPTION
This pull request implemented:
- Generation of schematic type structure
- Pumping upgrade of Mining Laser collecting fluid

# Schematic generation
- Implemented the use of schematic for structure generation. Finished incomplete code in original code base.
- To stay consistent with existing xml configuration, replacement tags accept `blockState` as property. Acceptable format include:
  - `modid:block` (wildcard to all blockstate)
  - `modid:block@property=value` (specific block state. This is the existing usage in default xml configurations)
  - `modid:block@meta` (specific integer meta value)
  - Separate `block` and `metadata` property is also supported. This is in line with existing implementation to `filler` definitions.
- Insertion node has new property `maxTries`. This indicate the max attempt to generate each selected loot before continue to the next. This is according to description provided in lootset xml file. Default attempt when not specified is 3. This is according to the default value used in `WorldGenStructure$fillInventoryWithLoot`.
- Note: Current implementation is O(m*n), m = amount of replacement/insertion, n = amount of blocks. This may cause slight lag when the structure is generated.
- Note: existing schematics (legacy1 and 2) have block ID mapping error, potentially due to error in WorldEdit format, or these files might be from older versions. I tested files with WarpDrive format, and no error were observed.


# Mining Laser Pumping
- This allow mining laser to collect fluid. It is implemented because some fluid generated in asteroid and moons may be useful (e.g. oil, liquid coal, lava).
- A new configuration option `pump_upgrade_pump_fluid` is added for mining laser.
- When enabled, mining laser with sufficient pump upgrade will attempt to collect fluid and pump to adjacent tank. Implementation mimics behaviour for item stack output.
- If adjacent tank are not present, fluid will be evaporated. This is assumed that the user do not need the fluid.
- If adjacent tank overflow, the laser will stop working. This is assumed the user need the fluid in such situation, in line with behaviour for item output.
- Note: the tooltip for pump upgrade in mining laser is not changed, therefore this functionality is not described anywhere even when enabled. I could not figure out a way to do that.
- Note: as it is unsure if this functionality is desired, the configuration is off by default.